### PR TITLE
add parameter to allow stale service health queries

### DIFF
--- a/consul.go
+++ b/consul.go
@@ -6,7 +6,8 @@ import (
 )
 
 type Consul struct {
-	client *api.Client
+	client    *api.Client
+	queryOpts *api.QueryOptions
 }
 
 type ConsulService struct {
@@ -18,7 +19,7 @@ type ConsulService struct {
 func (c *Consul) GetService(serviceName string) ([]ConsulService, error) {
 	serviceAddressesPorts := []ConsulService{}
 	// get consul service addresses and ports
-	addresses, _, err := c.client.Health().Service(serviceName, "", true, nil)
+	addresses, _, err := c.client.Health().Service(serviceName, "", true, c.queryOpts)
 	if err != nil {
 		return nil, errors.Wrap(err, "get consul service")
 	}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ const (
 	consulHTTPAddrFlag   = "consul-http-addr"
 	consulACLTokenFlag   = "consul-acl-token"
 	consulSchemeFlag     = "consul-scheme"
+	consulAllowStaleFlag = "consul-stale"
 
 	defaultPort             = 8080
 	defaultConsulDatacenter = "dc1"
@@ -71,6 +72,10 @@ func configureCli(app *cli.App) {
 			Value: defaultConsulScheme,
 			Usage: "The scheme for consul",
 		},
+		cli.BoolFlag{
+			Name:  consulAllowStaleFlag,
+			Usage: "Set stale parameter on consul service health queries",
+		},
 	}
 	cli.AppHelpTemplate = `{{.Name}} - {{.Usage}}
 
@@ -90,6 +95,7 @@ func validateConfig(c *cli.Context) (*ServerConfig, error) {
 	var consulHTTPAddr = c.String(consulHTTPAddrFlag)
 	var consulACLToken = os.Getenv("CONSUL_HTTP_TOKEN")
 	var consulScheme = c.String(consulSchemeFlag)
+	var consulAllowStaleFlag = c.Bool(consulAllowStaleFlag)
 
 	if !c.IsSet(consulHTTPAddrFlag) {
 		consulHTTPAddr = os.Getenv("CONSUL_HTTP_ADDR")
@@ -104,5 +110,6 @@ func validateConfig(c *cli.Context) (*ServerConfig, error) {
 		consulHTTPAddr:   consulHTTPAddr,
 		consulACLToken:   consulACLToken,
 		consulScheme:     consulScheme,
+		consulAllowStale: consulAllowStaleFlag,
 	}, nil
 }

--- a/server.go
+++ b/server.go
@@ -27,6 +27,7 @@ type ServerConfig struct {
 	consulHTTPAddr   string
 	consulACLToken   string
 	consulScheme     string
+	consulAllowStale bool
 }
 
 func NewServer(config *ServerConfig) (*Server, error) {
@@ -48,11 +49,17 @@ func NewServer(config *ServerConfig) (*Server, error) {
 		return nil, errors.Wrap(err, "initializing consul client")
 	}
 
+	var queryOpts *api.QueryOptions
+	if config.consulAllowStale {
+		queryOpts = &api.QueryOptions{AllowStale: true}
+
+	}
+
 	return &Server{
 		port:    config.port,
 		version: version,
 		engine:  engine,
-		consul:  &Consul{client: client},
+		consul:  &Consul{client: client, queryOpts: queryOpts},
 	}, nil
 }
 


### PR DESCRIPTION
- if parameter is not passed in, a nil QueryOptions pointer is still used (previous behavior)
- if paramter is marked true, then only the AllowStale struct field is set

the behavior of setQueryOptions on zero value struct members
- act on non-empty string values
- all boleans QueryOptions are checked for truthiness, default behavior is nothing on false
- single number type struct member only acts on > 0 values

the net effect is that only AllowStale is added by this change (intended at least)